### PR TITLE
Add additional explanation in readme

### DIFF
--- a/Initializable/Configurable.swift
+++ b/Initializable/Configurable.swift
@@ -40,6 +40,16 @@ import Foundation
    - returns: The current ReleaseStage
    */
   func currentStage() -> ReleaseStage
+
+  /**
+   This method is the default way to access configuration keys and values based on the current ReleaseStage
+
+   - parameter service: Key representing the service to pull keys from
+   - parameter key:     Key representing the service key to pull values from
+
+   - returns: Returns the stored service key value or nil if it's not present
+   */
+  optional func configurationValueForService(service: String, key: String) -> String?
 }
 
 public extension Configurable {


### PR DESCRIPTION
In order to make the library easier to integrate into projects, this
commit updates the readme with more explanation for integration. It also
adds an additional optional method to the Configurable protocol. This is
because the default implementation for
`configurationValueForService:key:` provided by the extension on
Configurable is not visible to Objective-C code. So in order to allow
better Objective-C integration, the optional method provides a means for
Objective-C code to pull service specific values from the object that
conforms to the Configurable protocol.
