### PR TITLE
Add support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 build/
+.build/
 *.pbxuser
 Carthage/Checkouts/
 !default.pbxuser

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,3 @@
+import PackageDescription
+
+let package = Package(name: "Initializable")

--- a/Sources/Initializable
+++ b/Sources/Initializable
@@ -1,0 +1,1 @@
+../Initializable


### PR DESCRIPTION
In order to support Swift Package Manager, this commit adds a couple new
files. The first is the Package.swift which declares our swift package.
The second is a directory containing a symlink to our actual codebase.
This is necessary in order to support both the traditional directory
structure that Xcode works with and the expected directory structure
that Swift Package Manager wants.
