### PR TITLE
Remove UIKit import from module header

### DIFF
--- a/Initializable.podspec
+++ b/Initializable.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Initializable"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "Application Initializer protocols"
 
   s.description  = <<-DESC

--- a/Initializable/Initializable.h
+++ b/Initializable/Initializable.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Wide Eye Labs. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for Initializable.
 FOUNDATION_EXPORT double InitializableVersionNumber;


### PR DESCRIPTION
In order to avoid pulling in unnecessary frameworks (UIKit), this commit
replaces the import with one pulling in Foundation instead.
